### PR TITLE
Exception in the load process of the object structure resolved

### DIFF
--- a/ng-providers/loadingManagerProvider.js
+++ b/ng-providers/loadingManagerProvider.js
@@ -242,7 +242,7 @@ angular.module('atlasDemo').provider('loadingManager', ['mainAppProvider', 'volu
 
         var objStructures = atlasStructure.Structure.filter(item => {
             if (Array.isArray(item.sourceSelector)) {
-                return item.sourceSelector.some(selector => /\.obj$/.test(selector.dataSource.source));
+                return item.sourceSelector.some(selector => /\.obj$/.test(selector.dataSource));
             }
             else {
                 return /\.obj$/.test(item.sourceSelector.dataSource.source);


### PR DESCRIPTION
Regular expression test generates a exception because it was looking for a dataSource.source field and there were elements in the array do not contain dataSource field.